### PR TITLE
Load without a partition key bugged

### DIFF
--- a/src/Core/AzureTableEntityStore.cs
+++ b/src/Core/AzureTableEntityStore.cs
@@ -16,7 +16,7 @@ public interface IKeyStrategy<in T> : IKeyStrategy
     string GetKey(T? entity = default);
 }
 
-class ConstantKeyStrategy<T> : IKeyStrategy<T>
+public class ConstantKeyStrategy<T> : IKeyStrategy<T>
 {
     private readonly IStoreConfiguration _configuration;
 
@@ -25,7 +25,7 @@ class ConstantKeyStrategy<T> : IKeyStrategy<T>
         _configuration = configuration;
     }
 
-    public string GetKey(T entity) => 
+    public string GetKey(T? entity) => 
         _configuration.DefaultPartitionKey;
 
     public bool IsUniqueValue => false;

--- a/src/Lab/Models/Organization.cs
+++ b/src/Lab/Models/Organization.cs
@@ -3,3 +3,5 @@
 public record Organization(string Id, string Name, string EmailDomain, string ExternalId, string ImageLinkId);
 
 public record Employee(string Id, string Name, string Team, string Department, DateTime StartDate);
+
+public record Assignment(string Id, string OrganizationId, string EmployeeId, DateTime Expiration);

--- a/src/Lab/Program.cs
+++ b/src/Lab/Program.cs
@@ -12,6 +12,7 @@ while (!shouldClose)
     Console.WriteLine();
     Console.WriteLine("1: Dual unique keys");
     Console.WriteLine("2: Dual non-unique keys");
+    Console.WriteLine("3: Single unique and single non-unique keys");
     Console.WriteLine();
     Console.Write("choice: ");
     var choice = Console.ReadLine();
@@ -35,6 +36,10 @@ while (!shouldClose)
             break;
         case "2":
             await NonUniqueKeyStrategyTesting.Run(connectionString);
+
+            break;
+        case "3":
+            await SingleUniqueSingleNonUnique.Run(connectionString);
 
             break;
         default:

--- a/src/Lab/UniqueKeyStrategyTesting.cs
+++ b/src/Lab/UniqueKeyStrategyTesting.cs
@@ -51,3 +51,25 @@ public static class NonUniqueKeyStrategyTesting
         await session.SaveChanges();
     }
 }
+public static class SingleUniqueSingleNonUnique
+{
+    public static async Task Run(string connectionString)
+    {
+        var strategies = new IKeyStrategy[]
+        {
+            new PropertyKeyStrategy<Assignment, string>(x => x.Id, true),
+            new PropertyKeyStrategy<Assignment, string>(x => x.OrganizationId, false),
+        };
+        var store = new AzureTableEntityStore(new StoreConfiguration
+        {
+            ConnectionString = connectionString,
+            Schema = "Lab"
+        }, strategies);
+        var session = store.OpenSession();
+
+        session.Store(new Assignment("2b4466cc-4775-4825-9840-dec5733bd359", "ABC123", "EMP-001", DateTime.Now));
+
+        await session.SaveChanges();
+        await session.SaveChanges();
+    }
+}


### PR DESCRIPTION
Issue is related to the default non-unique strategy being a guess and where this is not the ConstantValueKeyStrategy it's hard to load in the expected value